### PR TITLE
Fix mountain travel and final message

### DIFF
--- a/or78_6_mountain.py
+++ b/or78_6_mountain.py
@@ -53,7 +53,10 @@ def rugged_mountain(this_vars):
     if random.random() > 0.1:
         if random.random() > 0.11:
             print("THE GOING GETS SLOW")
-            this_vars.total_mileage -= 45 - (random.random / 0.2)
+            # random.random() was missing parentheses which resulted in a
+            # TypeError when subtracting a function object from a number.
+            # Use the generated random value instead.
+            this_vars.total_mileage -= 45 - (random.random() / 0.2)
             south_pass(this_vars)
         else:
             print("WAGON DAMAGED!—LOSE TIME AND SUPPLIES")

--- a/or78_7_endings.py
+++ b/or78_7_endings.py
@@ -13,7 +13,8 @@ def final_turn(this_vars):
         1 - this_vars.fraction_of_2_weeks
     ) * (8 + 5 * this_vars.choice_of_eating)
     print("YOU FINALLY ARRIVED AT OREGON CITY")
-    print("AFTER g_vars.GOAL_IN_MILES LONG MILES---HOORAY !!!!!")
+    # print the actual mileage goal reached instead of the literal text
+    print(f"AFTER {this_vars.GOAL_IN_MILES} LONG MILES---HOORAY !!!!!")
     print("A REAL PIONEER!")
     F9 = int(this_vars.fraction_of_2_weeks * 14)
     days = this_vars.current_date * 14 + F9


### PR DESCRIPTION
## Summary
- fix incorrect use of `random.random` when traveling through mountains
- print the real mileage in the final arrival message

## Testing
- `python -m py_compile *.py`
- `python - <<'EOF'
import or78_6_mountain as m
import or78_7_endings as e
from or78_vars import GameGlobals

vars = GameGlobals()
vars.current_date = 5
vars.total_mileage_previous_turn = 1000
vars.total_mileage = 2040
vars.amount_spent_on_food = 100
vars.choice_of_eating = 2
print('Testing final_turn:')
e.final_turn(vars)
print('Testing rugged_mountain:')
vars.total_mileage = 1000
m.rugged_mountain(vars)
print('Done')
EOF

------
https://chatgpt.com/codex/tasks/task_e_685a4ee0714083249e4882e078d5bc94