### PR TITLE
Fix print_date weekday

### DIFF
--- a/or78_2_date.py
+++ b/or78_2_date.py
@@ -38,7 +38,8 @@ def print_date(turn_number):
     """Display the current game date."""
 
     print("==================================================")
-    print(f"{weekdays[0]} {dates[turn_number]} 1847")
+    weekday = print_weekday(turn_number)
+    print(f"{weekday} {dates[turn_number]} 1847")
     print("==================================================")
 
 


### PR DESCRIPTION
## Summary
- compute weekday based on turn number in `print_date`

## Testing
- `pyflakes ./*.py`
- `python - <<'EOF'
import or78_2_date
for i in range(3):
    or78_2_date.print_date(i)
EOF
`

------
https://chatgpt.com/codex/tasks/task_e_685b7381b1288324aa9ea05517568406