### PR TITLE
Fix final date calculation bug

### DIFF
--- a/or78_2_date.py
+++ b/or78_2_date.py
@@ -62,7 +62,7 @@ def print_final_date(D3):
         return "{} OCTOBER {} 1847".format(weekday, D3 - 185)
     elif D3 > 155:
         return "{} SEPTEMBER {} 1847".format(weekday, D3 - 155)
-    elif D3 > 125:
+    elif D3 >= 125:
         return "{} AUGUST {} 1847".format(weekday, D3 - 124)
     else:
         return "{} JULY {} 1847".format(weekday, D3 - 93)

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -1,0 +1,9 @@
+import sys
+import os
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from or78_2_date import print_final_date
+
+def test_print_final_date_august_first():
+    assert print_final_date(125) == "FRIDAY AUGUST 1 1847"


### PR DESCRIPTION
## Summary
- correct off-by-one boundary in `print_final_date`
- add regression test for August 1 date

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7381b1288324aa9ea05517568406