### PR TITLE
Add CI workflow and expand date tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.11']
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+    - name: Run tests
+      run: |
+        pytest -q

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -5,5 +5,19 @@ import pytest
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from or78_2_date import print_final_date
 
-def test_print_final_date_august_first():
-    assert print_final_date(125) == "FRIDAY AUGUST 1 1847"
+
+@pytest.mark.parametrize(
+    "day_index,expected",
+    [
+        (124, "THURSDAY JULY 31 1847"),
+        (125, "FRIDAY AUGUST 1 1847"),
+        (155, "SUNDAY AUGUST 31 1847"),
+        (156, "MONDAY SEPTEMBER 1 1847"),
+        (216, "FRIDAY OCTOBER 31 1847"),
+        (217, "SATURDAY NOVEMBER 1 1847"),
+        (246, "SUNDAY NOVEMBER 30 1847"),
+        (247, "MONDAY DECEMBER 1 1847"),
+    ],
+)
+def test_print_final_date_boundaries(day_index, expected):
+    assert print_final_date(day_index) == expected


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run pytest
- add boundary tests for `print_final_date`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7e32c7a883248744f262b2cfb3e7