### PR TITLE
Expand tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,20 +7,21 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pytest
-    - name: Run tests
-      run: |
-        pytest -q
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Run tests
+        run: |
+          pytest -q

--- a/tests/test_blizzard.py
+++ b/tests/test_blizzard.py
@@ -1,0 +1,27 @@
+import sys
+import os
+from unittest import mock
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from or78_vars import GameGlobals
+from or78_6_mountain import blizzard
+
+
+def test_blizzard_event_damages_and_flags():
+    g = GameGlobals()
+    g.total_mileage = 1000
+    g.amount_spent_on_food = 100
+    g.amount_spent_on_miscellaneous = 50
+    g.amount_spent_on_bullets = 400
+    g.amount_spent_on_clothing = 10
+
+    with mock.patch('random.random', return_value=0):
+        with mock.patch('or78_helpers.illness') as mock_illness:
+            blizzard(g)
+            mock_illness.assert_called_once_with(g)
+
+    assert g.is_blizzard
+    assert g.amount_spent_on_food == 75
+    assert g.amount_spent_on_miscellaneous == 40
+    assert g.amount_spent_on_bullets == 100
+    assert g.total_mileage == 970

--- a/tests/test_game_globals.py
+++ b/tests/test_game_globals.py
@@ -1,0 +1,17 @@
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from or78_vars import GameGlobals
+from or78_2_date import dates
+
+
+def test_increment_turn_and_no_turns_left():
+    g = GameGlobals()
+    assert g.current_date == 0
+    assert not g.no_turns_left(dates)
+    g.increment_turn()
+    assert g.current_date == 1
+    assert not g.no_turns_left(dates)
+    g.current_date = len(dates)
+    assert g.no_turns_left(dates)

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -1,0 +1,21 @@
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from or78_3_loop import spend
+
+
+def test_spend_with_enough_money(capsys):
+    purse, value, success = spend(5, 10)
+    assert purse == 5
+    assert value == 5
+    assert success
+
+
+def test_spend_not_enough_money(capsys):
+    purse, value, success = spend(20, 10)
+    captured = capsys.readouterr().out
+    assert "YOU DON'T HAVE THAT MUCH" in captured
+    assert purse == 10
+    assert value == 20
+    assert not success


### PR DESCRIPTION
## Summary
- extend CI to cover multiple Python versions
- add blizzard unit test
- add GameGlobals unit test
- test spending logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b8d901e74832488a36595719b3113