### PR TITLE
Add tests for event and mountain logic

### DIFF
--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,26 @@
+import sys
+import os
+import random
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import or78_helpers
+from or78_vars import GameGlobals
+from or78_5_events import events_list, events as run_events
+
+
+def test_all_events_execute(monkeypatch):
+    monkeypatch.setattr(random, "random", lambda: 0.5)
+    monkeypatch.setattr(or78_helpers, "shooting", lambda *args, **kwargs: 0)
+    g = GameGlobals()
+    for ev in events_list:
+        g.dead = False
+        ev(g)
+
+
+def test_events_wrapper(monkeypatch):
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(random, "random", lambda: 0.5)
+    monkeypatch.setattr(or78_helpers, "shooting", lambda *args, **kwargs: 0)
+    g = GameGlobals()
+    run_events(g)

--- a/tests/test_mountain.py
+++ b/tests/test_mountain.py
@@ -1,0 +1,17 @@
+import sys
+import os
+import random
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import or78_helpers
+from or78_vars import GameGlobals
+from or78_6_mountain import mountain
+
+
+def test_mountain_progress(monkeypatch):
+    monkeypatch.setattr(random, "random", lambda: 0.5)
+    monkeypatch.setattr(or78_helpers, "illness", lambda *args, **kwargs: None)
+    g = GameGlobals()
+    g.total_mileage = 1000
+    mountain(g)


### PR DESCRIPTION
## Summary
- add tests for random events
- add tests for mountain progression logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b8d901e74832488a36595719b3113