### PR TITLE
Add integration test and AI CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,21 @@ jobs:
       - name: Run tests
         run: |
           pytest -q
+
+  ai-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Run AI mode tests
+        env:
+          AI_INTEGRATION: 'true'
+        run: |
+          pytest -q

--- a/tests/test_ai_integration.py
+++ b/tests/test_ai_integration.py
@@ -1,0 +1,6 @@
+import os
+import pytest
+
+@pytest.mark.skipif(os.environ.get("AI_INTEGRATION") != "true", reason="AI mode only")
+def test_ai_mode_placeholder():
+    assert True

--- a/tests/test_game_run.py
+++ b/tests/test_game_run.py
@@ -1,0 +1,36 @@
+import builtins
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import or78
+from or78_vars import GameGlobals
+
+
+def test_game_completes(monkeypatch, capsys):
+    class DummyGlobals(GameGlobals):
+        def __init__(self):
+            super().__init__()
+            self.cash_total = 0
+            self.total_mileage = self.GOAL_IN_MILES
+
+    monkeypatch.setattr(or78, "GameGlobals", DummyGlobals)
+    monkeypatch.setattr(or78, "init", lambda g: None)
+
+    # Patch out game functions that require user interaction or randomness
+    monkeypatch.setattr(or78, "print_date", lambda *_: None)
+    monkeypatch.setattr(or78, "begin", lambda *_: None)
+    monkeypatch.setattr(or78, "choices", lambda *_: None)
+    monkeypatch.setattr(or78, "toggle_fort_presence", lambda *_: None)
+    monkeypatch.setattr(or78, "eating", lambda *_: None)
+    monkeypatch.setattr(or78, "riders", lambda *_: None)
+    monkeypatch.setattr(or78, "events", lambda *_: None)
+    monkeypatch.setattr(or78, "mountain", lambda *_: None)
+    monkeypatch.setattr(or78, "final_turn", lambda *_: None)
+    monkeypatch.setattr(or78, "death", lambda *_: None)
+    monkeypatch.setattr(builtins, "input", lambda *_: "n")
+
+    or78.game()
+    captured = capsys.readouterr().out
+    assert "END" in captured


### PR DESCRIPTION
## Summary
- create a full game run test using monkeypatching
- add placeholder AI integration test
- extend CI workflow with a job that runs tests with `AI_INTEGRATION` enabled

## Testing
- `pytest -q`
- `AI_INTEGRATION=true pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b9e1a01a08324aaa9063ead7da301