### PR TITLE
Fix Blue Mountains flag typo

### DIFF
--- a/or78_6_mountain.py
+++ b/or78_6_mountain.py
@@ -25,10 +25,10 @@ def blue_mountain(this_vars):
     if this_vars.total_mileage < 1700:
         return
 
-    if this_vars.has_cleared_blue_montains:
+    if this_vars.has_cleared_blue_mountains:
         return
     else:
-        this_vars.has_cleared_blue_montains = True
+        this_vars.has_cleared_blue_mountains = True
         if random.random() < 0.7:
             blizzard(this_vars)
 

--- a/or78_vars.py
+++ b/or78_vars.py
@@ -29,7 +29,7 @@ class GameGlobals:
         # F1 = FLAG FOR CLEARING SOUTH PASS
         self.has_cleared_south_pass = False
         # F2 = FLAG FOR CLEARING BLUE MOUNTAINS
-        self.has_cleared_blue_montains = False
+        self.has_cleared_blue_mountains = False
         # F9 = FRACTION OF 2 WEEKS TRAVELED ON FINAL TURN
         self.fraction_of_2_weeks = 0
         # K8 = FLAG FOR INJURY


### PR DESCRIPTION
## Summary
- fix typo in the GameGlobals flag for clearing the Blue Mountains
- update mountain module to use the corrected attribute

## Testing
- `pytest -q`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_685e10ed7be0832490cbcbe3e06e6c13