### PR TITLE
Fix case-insensitive yes/no input

### DIFF
--- a/or78_helpers.py
+++ b/or78_helpers.py
@@ -5,10 +5,10 @@ import time
 
 
 def input_yes_no(message):
-    """Return ``True`` if the user's reply contains ``y``."""
+    """Return ``True`` if the user's reply starts with ``y`` (case-insensitive)."""
 
     reply = input(message)
-    return "y" in reply
+    return reply.strip().lower().startswith("y")
 
 
 def input_int(message):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,14 @@
+import builtins
+import or78_helpers
+
+
+def test_input_yes_no_variants(monkeypatch):
+    inputs = iter(['y', 'Y', 'Yes', 'n', 'N'])
+    results = []
+    monkeypatch.setattr(builtins, 'input', lambda _: next(inputs))
+    results.append(or78_helpers.input_yes_no('prompt'))  # 'y'
+    results.append(or78_helpers.input_yes_no('prompt'))  # 'Y'
+    results.append(or78_helpers.input_yes_no('prompt'))  # 'Yes'
+    results.append(or78_helpers.input_yes_no('prompt'))  # 'n'
+    results.append(or78_helpers.input_yes_no('prompt'))  # 'N'
+    assert results == [True, True, True, False, False]


### PR DESCRIPTION
## Summary
- handle uppercase replies in `input_yes_no`
- add regression tests for different yes/no variants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e52271a7883248a8ebcd96f7a8a85