### PR TITLE
Fix rider outcome bullet check

### DIFF
--- a/or78_4_riders.py
+++ b/or78_4_riders.py
@@ -6,7 +6,7 @@ def outcome(this_vars):
     """Print the result of a rider encounter."""
     if this_vars.hostility_of_riders:
         print("RIDERS WERE HOSTILE--CHECK FOR LOSSES")
-        if this_vars.amount_spent_on_bullets < 0:
+        if this_vars.amount_spent_on_bullets <= 0:
             print("YOU RAN OUT OF BULLETS AND GOT MASSACRED BY THE RIDERS")
             this_vars.dead = True
     else:

--- a/tests/test_riders.py
+++ b/tests/test_riders.py
@@ -1,0 +1,13 @@
+import builtins
+from or78_vars import GameGlobals
+from or78_4_riders import outcome
+
+
+def test_outcome_massacred_when_no_bullets(capsys):
+    g = GameGlobals()
+    g.amount_spent_on_bullets = 0
+    g.hostility_of_riders = True
+    outcome(g)
+    captured = capsys.readouterr().out
+    assert "MASSACRED" in captured
+    assert g.dead


### PR DESCRIPTION
## Summary
- fix bullet depletion check for hostile riders
- add regression test for rider massacre

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e52271a7883248a8ebcd96f7a8a85